### PR TITLE
update engine.io deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "engine.io": "^2.1.0",
-    "engine.io-client": "^2.1.0",
+    "engine.io": "^3.1.0",
+    "engine.io-client": "^3.1.0",
     "st": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
specifically to address vuln in ms - https://snyk.io/vuln/npm:ms:20170412

Note, this is a WIP - engine.io-client has not yet be updated to address the vuln, bug for that here:

* https://github.com/socketio/engine.io-client/issues/570